### PR TITLE
Unique Machine Identifier

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,6 +55,7 @@ add_library(${PROJECT_NAME} SHARED
         src/natives/nextclient.cpp
         src/natives/natives.h
         src/natives/natives.cpp
+        src/natives/hwid.cpp
 
         src/services/game_events/GameEventsManager.h
         src/services/game_events/GameEventsManager.cpp

--- a/src/natives/hwid.cpp
+++ b/src/natives/hwid.cpp
@@ -1,0 +1,75 @@
+#include <easylogging++.h>
+#include "amxxmodule.h"
+#include "api_access.h"
+#include "AmxContextGuard.h"
+
+// ---------------------------------------------------------------------------
+// ncl_get_client_hwid(index, hwid[], len)
+// ---------------------------------------------------------------------------
+static cell AMX_NATIVE_CALL ncl_get_client_hwid(AMX* amx, cell* params)
+{
+    AmxContextGuard guard(amx);
+    enum args_e
+    {
+        arg_count,
+        arg_index,
+        arg_hwid,
+        arg_len
+    };
+
+    if (MF_IsPlayerBot(params[arg_index]))
+    {
+        MF_SetAmxString(amx, params[arg_hwid], "", params[arg_len]);
+        return FALSE;
+    }
+
+    if (!MF_IsPlayerValid(params[arg_index]))
+    {
+        LOG(ERROR) << "ncl_get_client_hwid: invalid player index " << params[arg_index];
+        MF_SetAmxString(amx, params[arg_hwid], "", params[arg_len]);
+        return FALSE;
+    }
+
+    std::string hwid;
+    bool has_hwid = NAPI().GetClientHwid(params[arg_index], hwid);
+
+    MF_SetAmxString(amx, params[arg_hwid], hwid.c_str(), params[arg_len]);
+
+    return has_hwid ? TRUE : FALSE;
+}
+
+// ---------------------------------------------------------------------------
+// ncl_is_hwid_received(index)
+// ---------------------------------------------------------------------------
+static cell AMX_NATIVE_CALL ncl_is_hwid_received(AMX* amx, cell* params)
+{
+    AmxContextGuard guard(amx);
+    enum args_e
+    {
+        arg_count,
+        arg_index
+    };
+
+    if (MF_IsPlayerBot(params[arg_index]))
+        return FALSE;
+
+    if (!MF_IsPlayerValid(params[arg_index]))
+    {
+        LOG(ERROR) << "ncl_is_hwid_received: invalid player index " << params[arg_index];
+        return FALSE;
+    }
+
+    std::string hwid;
+    return NAPI().GetClientHwid(params[arg_index], hwid) ? TRUE : FALSE;
+}
+
+static AMX_NATIVE_INFO g_HwidNativeInfo[] = {
+    { "ncl_get_client_hwid",  ncl_get_client_hwid  },
+    { "ncl_is_hwid_received", ncl_is_hwid_received },
+    { nullptr, nullptr }
+};
+
+void AddNatives_Hwid()
+{
+    MF_AddNatives(g_HwidNativeInfo);
+}

--- a/src/natives/natives.cpp
+++ b/src/natives/natives.cpp
@@ -9,4 +9,5 @@ void AddNatives_All()
     AddNatives_DeathNoticeWpnIcon();
     AddNatives_HudSprite();
     AddNatives_Miscellaneous();
+    AddNatives_Hwid();
 }

--- a/src/natives/natives.h
+++ b/src/natives/natives.h
@@ -7,5 +7,6 @@ void AddNatives_ViewmodelFX();
 void AddNatives_DeathNoticeWpnIcon();
 void AddNatives_HudSprite();
 void AddNatives_Miscellaneous();
+void AddNatives_Hwid();
 
 void AddNatives_All();

--- a/src/services/NextClientApi.cpp
+++ b/src/services/NextClientApi.cpp
@@ -11,6 +11,7 @@ NextClientApi::NextClientApi(GameEventsManager& game_events_manager, NclmProtoco
     game_events_manager_.on_client_connected().connect(&NextClientApi::ClientConnectedHandler, this);
     game_events_manager_.on_client_connecting().connect(&NextClientApi::ClientConnectingHandler, this);
     nclm_protocol_.on_client_auth().connect(&NextClientApi::ClientAuthHandler, this);
+    nclm_protocol_.on_hwid_received().connect(&NextClientApi::HwidReceivedHandler, this); 
 }
 
 bool NextClientApi::IsClientReady(ClientId client)
@@ -96,6 +97,20 @@ int NextClientApi::GetSupportedFeatures(ClientId client)
     return features;
 }
 
+bool NextClientApi::GetClientHwid(ClientId client, std::string& hwid_out)
+{
+    auto it = players_.find(client);
+    if (it == players_.end())
+        return false;
+
+    const std::string& hwid = it->second.hwid;
+    if (hwid.empty())
+        return false;
+
+    hwid_out = hwid;
+    return true;
+}
+
 bool NextClientApi::ParseVersion(const std::string& in, NextClientVersion& out)
 {
     if (in.size() > 10)
@@ -116,7 +131,8 @@ bool NextClientApi::ParseVersion(const std::string& in, NextClientVersion& out)
 
 void NextClientApi::ServerActivatedHandler(ServerActivatedEvent event)
 {
-    forward_api_ready_ = MF_RegisterForward("ncl_client_api_ready", ET_IGNORE, FP_CELL, FP_DONE);
+    forward_api_ready_      = MF_RegisterForward("ncl_client_api_ready",  ET_IGNORE, FP_CELL, FP_DONE);
+    forward_hwid_received_  = MF_RegisterForward("ncl_hwid_received",     ET_IGNORE, FP_CELL, FP_STRING, FP_DONE);
 }
 
 void NextClientApi::ClientAuthHandler(ClientAuthEvent event)
@@ -138,12 +154,41 @@ void NextClientApi::ClientAuthHandler(ClientAuthEvent event)
 
     if (event.isVerified)
     {
-        LOG(INFO) << "Verified user " << name << " has joined the game (" <<  event.clientVersion << ")!";
+        LOG(INFO) << "Verified user " << name << " has joined the game (" << event.clientVersion << ")!";
     }
     else
     {
-        LOG(INFO) << "NextClient compatible user " << name << " has joined the game (" <<  event.clientVersion << ")!";
+        LOG(INFO) << "NextClient compatible user " << name << " has joined the game (" << event.clientVersion << ")!";
     }
+}
+
+void NextClientApi::HwidReceivedHandler(HwidReceivedEvent event)
+{
+    auto it = players_.find(event.client);
+    if (it == players_.end())
+        return;
+
+    PlayerData& player = it->second;
+
+    if (!player.is_verified)
+    {
+        LOG(WARNING) << "hwid: received from non-verified client "
+                     << MF_GetPlayerName(event.client) << " — ignored";
+        return;
+    }
+
+    if (!player.hwid.empty())
+    {
+        LOG(WARNING) << "hwid: duplicate from " << MF_GetPlayerName(event.client) << " — ignored";
+        return;
+    }
+
+    player.hwid = event.hwid;
+
+    LOG(INFO) << "hwid: stored for " << MF_GetPlayerName(event.client)
+              << " [" << player.hwid << "]";
+
+    MF_ExecuteForward(forward_hwid_received_, event.client, player.hwid.c_str());
 }
 
 void NextClientApi::PlayerPostThinkHandler(ClientId client)
@@ -167,6 +212,7 @@ void NextClientApi::ClientConnectedHandler(ClientId client)
     data.is_api_ready = false;
     data.is_verified = false;
     data.client_version = NextClientVersion{};
+    data.hwid = {};
 
     edict_t* entity = INDEXENT(client);
     if (!entity)

--- a/src/services/NextClientApi.h
+++ b/src/services/NextClientApi.h
@@ -15,6 +15,7 @@ class NextClientApi : public sigslot::observer, public INextClientInfo
 {
     std::unordered_map<ClientId, PlayerData> players_;
     int forward_api_ready_{};
+    int forward_hwid_received_{};
 
     GameEventsManager& game_events_manager_;
     NclmProtocol& nclm_protocol_;
@@ -28,11 +29,14 @@ public:
     bool GetNextClientVersion(ClientId client, NextClientVersion& version_out) override;
     int GetSupportedFeatures(ClientId client) override;
 
+    bool GetClientHwid(ClientId client, std::string& hwid_out);
+
 private:
     bool ParseVersion(const std::string& in, NextClientVersion& out);
 
     void ServerActivatedHandler(ServerActivatedEvent event);
     void ClientAuthHandler(ClientAuthEvent event);
+    void HwidReceivedHandler(HwidReceivedEvent event);
     void PlayerPostThinkHandler(ClientId client);
     void ClientConnectedHandler(ClientId client);
     void ClientConnectingHandler(ClientConnectingEvent event);

--- a/src/services/PlayerData.h
+++ b/src/services/PlayerData.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <string>
 #include "NextClientVersion.h"
 
 struct PlayerData
@@ -8,4 +9,6 @@ struct PlayerData
     bool is_using_nextclient{};
     bool is_api_ready{};
     bool is_verified{};
+
+    std::string hwid{};
 };

--- a/src/services/nclm_protocol/NclmProtocol.cpp
+++ b/src/services/nclm_protocol/NclmProtocol.cpp
@@ -30,6 +30,11 @@ sigslot::signal<ClientAuthEvent>& NclmProtocol::on_client_auth()
     return on_client_auth_;
 }
 
+sigslot::signal<HwidReceivedEvent>& NclmProtocol::on_hwid_received()
+{
+    return on_hwid_received_;
+}
+
 void NclmProtocol::NclMessageHandler(ClientId client, NCLM_C2S opcode)
 {
     switch (opcode)
@@ -44,6 +49,10 @@ void NclmProtocol::NclMessageHandler(ClientId client, NCLM_C2S opcode)
 
     case NCLM_C2S::DECLARE_VERSION_REQUEST:
         DeclareVersionHandler(client);
+        break;
+
+    case NCLM_C2S::HARDWARE_ID:
+        HardwareIdHandler(client);
         break;
     }
 }
@@ -117,6 +126,44 @@ void NclmProtocol::DeclareVersionHandler(ClientId client)
     on_client_auth_(ClientAuthEvent{client, client_version, false});
 }
 
+static bool IsValidHwidFormat(const std::string& hwid)
+{
+    if (hwid.size() != NCLM_HWID_SIZE)
+        return false;
+
+    for (char c : hwid)
+    {
+        if (!((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F')))
+            return false;
+    }
+    return true;
+}
+
+void NclmProtocol::HardwareIdHandler(ClientId client)
+{
+    std::string hwid = MSG_ReadString();
+
+    if (MSG_IsBadRead())
+    {
+        LOG(ERROR) << "hwid: badread on " << MF_GetPlayerName(client);
+        return;
+    }
+
+    if (!IsValidHwidFormat(hwid))
+    {
+        LOG(WARNING) << "hwid: invalid format from " << MF_GetPlayerName(client)
+                     << " (len=" << hwid.size() << ")";
+        return;
+    }
+
+    for (char& c : hwid)
+        c = static_cast<char>(tolower(static_cast<unsigned char>(c)));
+
+    LOG(INFO) << "hwid: received from " << MF_GetPlayerName(client)
+              << " [" << hwid << "]";
+
+    on_hwid_received_(HwidReceivedEvent{client, hwid});
+}
 
 void NclmProtocol::ClientMessageHandler(IRehldsHook_HandleNetCommand* hookchain, IGameClient* apiClient, int8 opcode)
 {

--- a/src/services/nclm_protocol/NclmProtocol.h
+++ b/src/services/nclm_protocol/NclmProtocol.h
@@ -13,7 +13,8 @@ class NclmProtocol : public sigslot::observer
     friend void HandleNetCommand(IRehldsHook_HandleNetCommand* hookchain, IGameClient* apiClient, int8 opcode);
 
     Verifier verifier_;
-    sigslot::signal<ClientAuthEvent> on_client_auth_;
+    sigslot::signal<ClientAuthEvent>    on_client_auth_;
+    sigslot::signal<HwidReceivedEvent>  on_hwid_received_;
     std::unordered_map<ClientId, VerificationPayload> player_data_;
 
     static NclmProtocol* instance_;
@@ -22,13 +23,15 @@ public:
     explicit NclmProtocol(GameEventsManager& game_events_manager);
     ~NclmProtocol() override;
 
-    sigslot::signal<ClientAuthEvent>& on_client_auth();
+    sigslot::signal<ClientAuthEvent>&   on_client_auth();
+    sigslot::signal<HwidReceivedEvent>& on_hwid_received();
 
 private:
     void NclMessageHandler(ClientId client, NCLM_C2S opcode);
     void VerificationRequestHandler(ClientId client);
     void VerificationChallengeHandler(ClientId client);
     void DeclareVersionHandler(ClientId client);
+    void HardwareIdHandler(ClientId client); 
     void ClientMessageHandler(IRehldsHook_HandleNetCommand* hookchain, IGameClient* apiClient, int8 opcode);
     void ServerActivatedHandler(ServerActivatedEvent event);
     void SendServerInfoHandler(ClientId);

--- a/src/services/nclm_protocol/events.h
+++ b/src/services/nclm_protocol/events.h
@@ -8,3 +8,9 @@ struct ClientAuthEvent
     std::string clientVersion;
     bool isVerified;
 };
+
+struct HwidReceivedEvent
+{
+    ClientId    client;
+    std::string hwid;   // 64-char hex SHA-256
+};

--- a/src/services/nclm_protocol/nclm_proto.h
+++ b/src/services/nclm_protocol/nclm_proto.h
@@ -9,6 +9,8 @@ constexpr size_t RSA_KEY_LENGTH =			256;
 constexpr size_t NCLM_VERIF_PAYLOAD_SIZE =	196;
 constexpr size_t NCLM_VERIF_ENCRYPTED_PAYLOAD_SIZE = ((NCLM_VERIF_PAYLOAD_SIZE / RSA_KEY_LENGTH) + 1) * RSA_KEY_LENGTH;
 
+constexpr size_t NCLM_HWID_SIZE = 64;
+
 enum class NCLM_C2S
 {
 	/*
@@ -28,7 +30,20 @@ enum class NCLM_C2S
 	 * Used to tell the server the version of NextClient in use
 	 * when the private key in the client is not configured.
 	 */
-	DECLARE_VERSION_REQUEST
+	DECLARE_VERSION_REQUEST,
+
+	/*
+	 * HWID identification.
+	 * Only sent by verified clients (post RSA handshake).
+	 *
+	 * Payload:
+	 *   byte      This opcode (0x04)
+	 *   string    64-char lowercase hex SHA-256 of hardware identifiers
+	 *
+	 * Non-NextClient or older clients will never send this opcode.
+	 * Server must NOT kick clients that omit it — store empty string instead.
+	 */
+	HARDWARE_ID                         // = 0x04 (sequential)
 };
 
 enum class NCLM_S2C


### PR DESCRIPTION
NextClientServerApi (Server-Side)
Description: A Metamod/AMX Mod X module designed to manage extended features for NextClient-enabled servers.
Key Feature: HWID Management & AMXX Integration.

Persistence: Intercepts NCLM hardware packets and binds the unique hash to the player's session.

Scripting API: Provides native functions (ncl_get_client_hwid) for Pawn developers to create hardware-based ban systems, VIP persistence, or account security.

Validation: Includes safety checks to distinguish between real players and bots/invalid indices.


https://github.com/CS-NextClient/NextClientServerApi/issues/6